### PR TITLE
Ny håndtering av tiltaksperioder

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/domain/SøknadDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/domain/SøknadDTO.kt
@@ -85,6 +85,7 @@ data class SøknadDTO(
                     arrangør = req.tiltak.arrangør,
                     type = req.tiltak.type,
                     typeNavn = req.tiltak.typeNavn,
+                    arenaRegistrertPeriode = req.tiltak.arenaRegistrertPeriode,
                 ),
                 vedleggsnavn = vedleggsnavn,
                 barnetillegg = Barnetillegg(

--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/SpørsmålsbesvarelserDTO.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/SpørsmålsbesvarelserDTO.kt
@@ -1,5 +1,6 @@
 package no.nav.tiltakspenger.soknad.api.soknad
 
+import no.nav.tiltakspenger.soknad.api.tiltak.Deltakelsesperiode
 import java.time.LocalDate
 
 data class Periode(
@@ -40,7 +41,8 @@ data class Institusjonsopphold(
 data class Tiltak(
     val aktivitetId: String,
     val periode: Periode,
-    val søkerHeleTiltaksperioden: Boolean,
+    val arenaRegistrertPeriode: Deltakelsesperiode?,
+    val søkerHeleTiltaksperioden: Boolean?,
     val arrangør: String,
     val type: String,
     val typeNavn: String,

--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/tiltak/TiltakDto.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/tiltak/TiltakDto.kt
@@ -12,7 +12,7 @@ data class TiltaksdeltakelseDto(
     val aktivitetId: String,
     val type: ArenaTiltaksaktivitetResponsDTO.TiltakType,
     val typeNavn: String,
-    val deltakelsePeriode: Deltakelsesperiode,
+    val arenaRegistrertPeriode: Deltakelsesperiode,
     val arrangør: String,
     val status: ArenaTiltaksaktivitetResponsDTO.DeltakerStatusType,
 ) {
@@ -20,12 +20,12 @@ data class TiltaksdeltakelseDto(
         val datoFor6MånederSiden = LocalDate.now().minusMonths(6)
         val dato2MånederFrem = LocalDate.now().plusMonths(2)
 
-        return if (deltakelsePeriode.fra == null) {
+        return if (arenaRegistrertPeriode.fra == null) {
             true
-        } else if (deltakelsePeriode.til == null) {
-            deltakelsePeriode.fra.isBefore(dato2MånederFrem) && deltakelsePeriode.fra.isAfter(datoFor6MånederSiden)
+        } else if (arenaRegistrertPeriode.til == null) {
+            arenaRegistrertPeriode.fra.isBefore(dato2MånederFrem) && arenaRegistrertPeriode.fra.isAfter(datoFor6MånederSiden)
         } else {
-            deltakelsePeriode.fra.isBefore(dato2MånederFrem) && deltakelsePeriode.til.isAfter(datoFor6MånederSiden)
+            arenaRegistrertPeriode.fra.isBefore(dato2MånederFrem) && arenaRegistrertPeriode.til.isAfter(datoFor6MånederSiden)
         }
     }
 
@@ -54,7 +54,7 @@ data class ArenaTiltakResponse(
                     aktivitetId = it.aktivitetId,
                     type = it.tiltakType,
                     typeNavn = it.tiltakType.navn,
-                    deltakelsePeriode = Deltakelsesperiode(
+                    arenaRegistrertPeriode = Deltakelsesperiode(
                         fra = it.deltakelsePeriode?.fom,
                         til = it.deltakelsePeriode?.tom,
                     ),

--- a/src/test/kotlin/no/nav/tiltakspenger/soknad/api/joark/JoarkClientTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/soknad/api/joark/JoarkClientTest.kt
@@ -24,6 +24,7 @@ import no.nav.tiltakspenger.soknad.api.soknad.Kvalifiseringsprogram
 import no.nav.tiltakspenger.soknad.api.soknad.Pensjonsordning
 import no.nav.tiltakspenger.soknad.api.soknad.Periode
 import no.nav.tiltakspenger.soknad.api.soknad.Tiltak
+import no.nav.tiltakspenger.soknad.api.tiltak.Deltakelsesperiode
 import no.nav.tiltakspenger.soknad.api.vedlegg.Vedlegg
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -234,6 +235,10 @@ internal class JoarkClientTest {
                 arrangør = "test",
                 type = "test",
                 typeNavn = "test",
+                arenaRegistrertPeriode = Deltakelsesperiode(
+                    fra = LocalDate.MAX,
+                    til = LocalDate.MAX,
+                ),
             ),
             etterlønn = Etterlønn(
                 mottarEllerSøktEtterlønn = false,

--- a/src/test/kotlin/no/nav/tiltakspenger/soknad/api/pdf/PdfClientTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/soknad/api/pdf/PdfClientTest.kt
@@ -22,6 +22,7 @@ import no.nav.tiltakspenger.soknad.api.soknad.Kvalifiseringsprogram
 import no.nav.tiltakspenger.soknad.api.soknad.Pensjonsordning
 import no.nav.tiltakspenger.soknad.api.soknad.Periode
 import no.nav.tiltakspenger.soknad.api.soknad.Tiltak
+import no.nav.tiltakspenger.soknad.api.tiltak.Deltakelsesperiode
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -107,6 +108,10 @@ internal class PdfClientTest {
             arrangør = "test",
             type = "test",
             typeNavn = "test",
+            arenaRegistrertPeriode = Deltakelsesperiode(
+                fra = LocalDate.MAX,
+                til = LocalDate.MAX,
+            ),
         ),
         etterlønn = Etterlønn(
             mottarEllerSøktEtterlønn = false,


### PR DESCRIPTION
* Navnet på deltakelsePeriode på TiltakDto er nå endret til arenaRegistrertPeriode
* Støtte å ta imot en optional arenaRegistrertPeriode ved post /soknad
* Gjøre søkerHeleTiltaksperioden optional, siden dette feltet ikke blir med når vi mangler en periode på valgt tiltak