### PR TITLE
Håndtere 409 fra dokarkiv

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/joark/JoarkClient.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/joark/JoarkClient.kt
@@ -2,6 +2,7 @@ package no.nav.tiltakspenger.soknad.api.joark
 
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.request.accept
 import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.header
@@ -87,6 +88,11 @@ class JoarkClient(
                 }
             }
         } catch (throwable: Throwable) {
+            if (throwable is ClientRequestException && throwable.response.status == HttpStatusCode.Conflict) {
+                log.info("Søknaden har allerede blitt journalført (409 Conflict)")
+                val response = throwable.response.call.body<JoarkResponse>()
+                return response.journalpostId.orEmpty()
+            }
             if (throwable is IllegalStateException) {
                 throw throwable
             } else {

--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/joark/JoarkClient.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/joark/JoarkClient.kt
@@ -89,7 +89,7 @@ class JoarkClient(
             }
         } catch (throwable: Throwable) {
             if (throwable is ClientRequestException && throwable.response.status == HttpStatusCode.Conflict) {
-                log.info("Søknaden har allerede blitt journalført (409 Conflict)")
+                log.warn("Søknaden har allerede blitt journalført (409 Conflict)")
                 val response = throwable.response.call.body<JoarkResponse>()
                 return response.journalpostId.orEmpty()
             }

--- a/src/test/kotlin/no/nav/tiltakspenger/soknad/api/joark/JoarkClientTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/soknad/api/joark/JoarkClientTest.kt
@@ -89,6 +89,36 @@ internal class JoarkClientTest {
         }
     }
 
+    @Test
+    fun `hvis joark svarer med 409 Conflict returnerer opprettJournalpost en journalpostId hvis vi har fått en`() {
+        val mock = MockEngine {
+            respond(
+                content = okSvarJoark,
+                status = HttpStatusCode.Conflict,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+
+        val mockTokenService = mockk<TokenService>()
+        coEvery { mockTokenService.getToken(any()) } returns "token"
+
+        val client = httpClientGeneric(mock)
+        val config = ApplicationConfig("application.test.conf")
+        val joarkClient = JoarkClient(
+            config = config,
+            client = client,
+            tokenService = mockTokenService,
+        )
+
+        runTest {
+            val resp = joarkClient.opprettJournalpost(
+                dokumentInnhold = dokument,
+                callId = "test",
+            )
+            resp shouldBe journalpostId
+        }
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `joark svarer med feil`() {


### PR DESCRIPTION
Sørger for at vi håndterer 409 Conflict fra dokarkiv.

Håndteringen per nå er at vi logger at man har prøvd å journalføre duplikat, men at joak klienten svarer som normalt, for å unngå at bruker får feilmelding