### PR TITLE
Fjern forelderbarnrelasjon

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/pdl/SøkerRespons.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/pdl/SøkerRespons.kt
@@ -6,7 +6,9 @@ data class SøkerFraPDL(
     val navn: List<Navn>,
     val adressebeskyttelse: List<Adressebeskyttelse>,
     val foedselsdato: List<Fødsel>,
-    val forelderBarnRelasjon: List<ForelderBarnRelasjon>,
+
+    // KEW Denne er midlertidig fjernet siden den ikke brukes per nå: https://trello.com/c/NQzRwuNf/1129-fjern-foreldre-barn-relasjon-i-personquery-mot-pdl
+    // val forelderBarnRelasjon: List<ForelderBarnRelasjon>,
     val doedsfall: List<Dødsfall>,
 )
 
@@ -39,7 +41,6 @@ data class SøkerRespons(
             mellomnavn = navn.mellomnavn,
             etternavn = navn.etternavn,
             fødselsdato = fødsel.foedselsdato,
-            forelderBarnRelasjon = person.forelderBarnRelasjon,
             adressebeskyttelseGradering = adressebeskyttelseGradering,
             erDød = false,
         )

--- a/src/main/resources/hentPersonQuery.graphql
+++ b/src/main/resources/hentPersonQuery.graphql
@@ -9,16 +9,6 @@ query($ident: ID!){
                 ...metadataDetails
             }
         }
-        forelderBarnRelasjon {
-            relatertPersonsIdent
-            relatertPersonsRolle
-            folkeregistermetadata {
-                ...folkeregistermetadataDetails
-            }
-            metadata {
-                ...metadataDetails
-            }
-        }
         navn(historikk: false) {
             fornavn
             mellomnavn

--- a/src/test/kotlin/no/nav/tiltakspenger/soknad/api/pdl/PdlServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/soknad/api/pdl/PdlServiceTest.kt
@@ -8,6 +8,7 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
@@ -167,7 +168,7 @@ internal class PdlServiceTest {
                 coEvery { mock.fetchSøker(any(), any(), any()) } returns Result.success(
                     mockSøkerRespons(
                         forelderBarnRelasjon = listOf(
-                            mockForelderBarnRelasjon(),
+//                            mockForelderBarnRelasjon(),
                         ),
                     ),
                 )
@@ -178,7 +179,7 @@ internal class PdlServiceTest {
                 callId = "test",
             )
             coVerify { mockedTokenXClient.fetchSøker(testFødselsnummer, token, "test") }
-            coVerify { mockedCredentialsClient.fetchBarn(testBarnFødselsnummer, "test") }
+//            coVerify { mockedCredentialsClient.fetchBarn(testBarnFødselsnummer, "test") }
         }
     }
 
@@ -243,6 +244,7 @@ internal class PdlServiceTest {
         }
     }
 
+    @Disabled // Kew, denne er disablet frem til forelderBarnRelasjon skal brukes igjen
     @Test
     fun `hentPersonaliaMedBarn skal returnere barn fra forelderBarnRelasjon som er under 16 år`() {
         val token = "token"
@@ -269,6 +271,7 @@ internal class PdlServiceTest {
         }
     }
 
+    @Disabled // Kew, denne er disablet frem til forelderBarnRelasjon skal brukes igjen
     @Test
     fun `hentPersonaliaMedBarn skal kun returnere fødselsdato på barn som er STRENGT_FORTROLIG`() {
         val token = "token"
@@ -300,6 +303,7 @@ internal class PdlServiceTest {
         }
     }
 
+    @Disabled // Kew, denne er disablet frem til forelderBarnRelasjon skal brukes igjen
     @Test
     fun `hentPersonaliaMedBarn skal kun returnere fødselsdato på barn som er FORTROLIG`() {
         val token = "token"
@@ -331,6 +335,7 @@ internal class PdlServiceTest {
         }
     }
 
+    @Disabled // Kew, denne er disablet frem til forelderBarnRelasjon skal brukes igjen
     @Test
     fun `hentPersonaliaMedBarn skal kun returnere fødselsdato på barn som er STRENGT_FORTROLIG_UTLAND`() {
         val token = "token"
@@ -362,6 +367,7 @@ internal class PdlServiceTest {
         }
     }
 
+    @Disabled // Kew, denne er disablet frem til forelderBarnRelasjon skal brukes igjen
     @Test
     fun `hentPersonaliaMedBarn skal returnere barn med fornavn, mellomnavn og etternavn, når barnet er UGRADERT`() {
         val token = "token"
@@ -400,6 +406,7 @@ internal class PdlServiceTest {
         etternavn = this.data?.hentPerson?.navn?.first()!!.etternavn,
     )
 
+    @Disabled // Kew, denne er disablet frem til forelderBarnRelasjon skal brukes igjen
     @Test
     fun `hentPersonaliaMedBarn skal filtrere vekk barn som er over 16 år på styrendeDato`() {
         val token = "token"

--- a/src/test/kotlin/no/nav/tiltakspenger/soknad/api/pdl/PdlServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/soknad/api/pdl/PdlServiceTest.kt
@@ -81,7 +81,8 @@ internal class PdlServiceTest {
                 hentPerson = SøkerFraPDL(
                     navn = listOf(mockNavn()),
                     adressebeskyttelse = emptyList(),
-                    forelderBarnRelasjon = forelderBarnRelasjon,
+                    // KEW Denne er midlertidig fjernet siden den ikke brukes per nå: https://trello.com/c/NQzRwuNf/1129-fjern-foreldre-barn-relasjon-i-personquery-mot-pdl
+                    // forelderBarnRelasjon = forelderBarnRelasjon,
                     doedsfall = emptyList(),
                     foedselsdato = listOf(mockFødsel()),
                 ),


### PR DESCRIPTION
## Beskrivelse
Fjern forelderBarnRelasjon fra PDL-query siden vi ikke vil behandle disse dataene da vi ikke bruker denne infoen til noe enda

## Kommentarer
<!--- Er det noe mer som bør opplyses om til den som ser over? -->
