### PR TITLE
henter journalførende enhet

### DIFF
--- a/.nais/nais.yml
+++ b/.nais/nais.yml
@@ -60,6 +60,7 @@ spec:
         - host: {{outboundExternalUrls.pdl}}
         - host: {{outboundExternalUrls.dokarkiv}}
         - host: {{outboundExternalUrls.tiltakspengerarena}}
+        - host: {{outboundExternalUrls.norg2}}
         - host: "tiltakspenger-unleash-api.nav.cloud.nais.io"
   env:
     - name: PDL_ENDPOINT_URL
@@ -92,6 +93,10 @@ spec:
       value: {{ audience.tiltakspengertiltak }}
     - name: UNLEASH_ENVIRONMENT
       value: {{ unleash.environment }}
+    - name: NORG2_ENDPOINT_URL
+      value: {{ endpoints.norg2 }}
+    - name: NORG2_AUDIENCE
+      value: {{ audience.norg2 }}
   envFrom:
     - secret: tiltakspenger-soknad-api-unleash-api-token
   resources:

--- a/.nais/vars/dev.yml
+++ b/.nais/vars/dev.yml
@@ -9,16 +9,19 @@ endpoints:
   tiltakspengertiltak: http://tiltakspenger-tiltak
   tiltakspengervedtak: http://tiltakspenger-saksbehandling-api
   av: http://clamav.nais-system/scan
+  norg2: https://norg2.dev-fss-pub.nais.io
 
 outboundExternalUrls:
   pdl: pdl-api.dev-fss-pub.nais.io
   dokarkiv: dokarkiv-q2.dev-fss-pub.nais.io
   tiltakspengerarena: tiltakspenger-arena.dev-fss-pub.nais.io
+  norg2: norg2.dev-fss-pub.nais.io
 audience:
   pdl: dev-fss:pdl:pdl-api
   joark: dev-fss:teamdokumenthandtering:dokarkiv
   tiltakspengerarena: dev-fss:tpts:tiltakspenger-arena
   tiltakspengertiltak: dev-gcp:tpts:tiltakspenger-tiltak
+  norg2: dev-fss:org:norg2
 scope:
   pdl: api://dev-fss.pdl.pdl-api/.default
   joark: api://dev-fss.teamdokumenthandtering.dokarkiv/.default

--- a/.nais/vars/prod.yml
+++ b/.nais/vars/prod.yml
@@ -9,15 +9,18 @@ endpoints:
   tiltakspengertiltak: http://tiltakspenger-tiltak
   tiltakspengervedtak: http://tiltakspenger-saksbehandling-api
   av: http://clamav.nais-system/scan
+  norg2: https://norg2.prod-fss-pub.nais.io
 outboundExternalUrls:
   pdl: pdl-api.prod-fss-pub.nais.io
   dokarkiv: dokarkiv.prod-fss-pub.nais.io
   tiltakspengerarena: tiltakspenger-arena.prod-fss-pub.nais.io
+  norg2: norg2.prod-fss-pub.nais.io
 audience:
   pdl: prod-fss:pdl:pdl-api
   joark: prod-fss:teamdokumenthandtering:dokarkiv
   tiltakspengerarena: prod-fss:tpts:tiltakspenger-arena
   tiltakspengertiltak: prod-gcp:tpts:tiltakspenger-tiltak
+  norg2: prod-fss:org:norg2
 scope:
   pdl: api://prod-fss.pdl.pdl-api/.default
   joark: api://prod-fss.teamdokumenthandtering.dokarkiv/.default

--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/joark/JoarkCredentialsClient.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/joark/JoarkCredentialsClient.kt
@@ -3,7 +3,6 @@ package no.nav.tiltakspenger.soknad.api.joark
 import io.ktor.client.HttpClient
 import io.ktor.server.config.ApplicationConfig
 import no.nav.tiltakspenger.soknad.api.auth.oauth.ClientConfig
-import no.nav.tiltakspenger.soknad.api.extensions.getAccessTokenOrThrow
 import no.nav.tiltakspenger.soknad.api.httpClientWithRetry
 
 class JoarkCredentialsClient(
@@ -15,7 +14,6 @@ class JoarkCredentialsClient(
 
     suspend fun getToken(): String {
         val clientCredentialsGrant = oauth2CredentialsClient.clientCredentials(joarkScope)
-        val token = clientCredentialsGrant.getAccessTokenOrThrow()
-        return token
+        return clientCredentialsGrant.token
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/pdl/PdlCredentialsClient.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/pdl/PdlCredentialsClient.kt
@@ -12,7 +12,6 @@ import io.ktor.http.contentType
 import io.ktor.server.config.ApplicationConfig
 import mu.KotlinLogging
 import no.nav.tiltakspenger.soknad.api.auth.oauth.ClientConfig
-import no.nav.tiltakspenger.soknad.api.extensions.getAccessTokenOrThrow
 import no.nav.tiltakspenger.soknad.api.httpClientWithRetry
 
 class PdlCredentialsClient(
@@ -26,9 +25,7 @@ class PdlCredentialsClient(
 
     suspend fun fetchBarn(ident: String, callId: String): Result<SøkersBarnRespons> {
         log.info("Henter credentials for å snakke med PDL")
-        val clientCredentialsGrant = oauth2CredentialsClient.clientCredentials(pdlScope)
-        log.info("Credentials-respons mottatt")
-        val token = clientCredentialsGrant.getAccessTokenOrThrow()
+        val token = oauth2CredentialsClient.clientCredentials(pdlScope).token
         log.info("Hent credentials OK")
         return kotlin.runCatching {
             httpClient.post(pdlEndpoint) {

--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/jobb/SøknadJobbServiceImpl.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/jobb/SøknadJobbServiceImpl.kt
@@ -6,13 +6,13 @@ import no.nav.tiltakspenger.libs.logging.sikkerlogg
 import no.nav.tiltakspenger.soknad.api.saksbehandlingApi.SendSøknadTilSaksbehandlingApiService
 import no.nav.tiltakspenger.soknad.api.soknad.SøknadRepo
 import no.nav.tiltakspenger.soknad.api.soknad.SøknadService
-import no.nav.tiltakspenger.soknad.api.soknad.jobb.person.PersonGateway
+import no.nav.tiltakspenger.soknad.api.soknad.jobb.person.PersonHttpklient
 import no.nav.tiltakspenger.soknad.api.soknad.log
 import java.time.LocalDateTime
 
 class SøknadJobbServiceImpl(
     private val søknadRepo: SøknadRepo,
-    private val personGateway: PersonGateway,
+    private val personHttpklient: PersonHttpklient,
     private val søknadService: SøknadService,
     private val sendSøknadTilSaksbehandlingApiService: SendSøknadTilSaksbehandlingApiService,
 ) : SøknadJobbService {
@@ -21,7 +21,7 @@ class SøknadJobbServiceImpl(
             log.info { "Journalfør søknad jobb: Prøver å journalføre søknad med søknadId ${søknad.id}" }
 
             val navn = try {
-                personGateway.hentNavnForFnr(Fnr.fromString(søknad.fnr))
+                personHttpklient.hentNavnForFnr(Fnr.fromString(søknad.fnr))
             } catch (e: Exception) {
                 log.error(RuntimeException("Trigger stacktrace for enklere debug.")) { "Journalfør søknad jobb: Feil ved henting av navn fra PDL for søknadId ${søknad.id}" }
                 sikkerlogg.error(e) { "Journalfør søknad jobb: Feil ved henting av navn fra PDL for søknadId ${søknad.id}" }

--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/jobb/journalforendeEnhet/JournalforendeEnhetService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/jobb/journalforendeEnhet/JournalforendeEnhetService.kt
@@ -1,0 +1,29 @@
+package no.nav.tiltakspenger.soknad.api.soknad.jobb.journalforendeEnhet
+
+import no.nav.tiltakspenger.soknad.api.pdl.AdressebeskyttelseGradering
+import no.nav.tiltakspenger.soknad.api.soknad.jobb.journalforendeEnhet.arbeidsfordeling.ArbeidsfordelingClient
+import no.nav.tiltakspenger.soknad.api.soknad.jobb.journalforendeEnhet.arbeidsfordeling.ArbeidsfordelingRequest
+import no.nav.tiltakspenger.soknad.api.soknad.jobb.person.Person
+import no.nav.tiltakspenger.soknad.api.soknad.log
+
+class JournalforendeEnhetService(
+    private val arbeidsfordelingClient: ArbeidsfordelingClient,
+) {
+    suspend fun finnJournalforendeEnhet(person: Person): String {
+        val arbeidsfordelingRequest = ArbeidsfordelingRequest(
+            diskresjonskode = getDiskresjonskode(person.adressebeskyttelseGradering),
+            geografiskOmraade = person.geografiskTilknytning?.getGT(),
+        )
+        return arbeidsfordelingClient.hentArbeidsfordeling(arbeidsfordelingRequest)
+            .also { log.info { "Fant journalførende enhet $it" } }
+    }
+
+    private fun getDiskresjonskode(adressebeskyttelseGradering: AdressebeskyttelseGradering) =
+        when (adressebeskyttelseGradering) {
+            AdressebeskyttelseGradering.STRENGT_FORTROLIG_UTLAND,
+            AdressebeskyttelseGradering.STRENGT_FORTROLIG,
+            -> "SPSF"
+            AdressebeskyttelseGradering.FORTROLIG -> "SPFO"
+            else -> null
+        }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/jobb/journalforendeEnhet/arbeidsfordeling/ArbeidsfordelingClient.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/jobb/journalforendeEnhet/arbeidsfordeling/ArbeidsfordelingClient.kt
@@ -1,0 +1,56 @@
+package no.nav.tiltakspenger.soknad.api.soknad.jobb.journalforendeEnhet.arbeidsfordeling
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.accept
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import no.nav.tiltakspenger.libs.common.AccessToken
+import no.nav.tiltakspenger.soknad.api.httpClientWithRetry
+import no.nav.tiltakspenger.soknad.api.objectMapper
+import org.slf4j.LoggerFactory
+
+class ArbeidsfordelingClient(
+    private val httpClient: HttpClient = httpClientWithRetry(timeout = 5L),
+    private val baseUrl: String,
+    private val getToken: suspend () -> AccessToken,
+) {
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    suspend fun hentArbeidsfordeling(request: ArbeidsfordelingRequest): String {
+        val response = httpClient.post("$baseUrl/api/v1/arbeidsfordeling/enheter/bestmatch") {
+            accept(ContentType.Application.Json)
+            bearerAuth(getToken().token)
+            header("Nav-Consumer-Id", "tiltakspenger-soknad-api")
+            contentType(ContentType.Application.Json)
+            setBody(objectMapper.writeValueAsString(request))
+        }
+        if (response.status.isSuccess()) {
+            val enheter = response.body<List<NavEnhet>>()
+            if (enheter.isEmpty()) {
+                log.error("Fant ingen enheter")
+                throw IllegalArgumentException("Fant ingen enheter")
+            }
+            return enheter.first().enhetNr
+        }
+        log.error("Kall mot norg2 for å hente arbeidsfordeling feilet med statuskode ${response.status}")
+        throw RuntimeException("Kunne ikke hente arbeidsfordeling")
+    }
+}
+
+data class ArbeidsfordelingRequest(
+    val diskresjonskode: String?,
+    val oppgavetype: String = "BEH_SAK",
+    val tema: String = "IND",
+    val geografiskOmraade: String?,
+    val skjermet: Boolean = false,
+)
+
+private data class NavEnhet(
+    val enhetNr: String,
+)

--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/jobb/person/HentPersonNavnQuery.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/jobb/person/HentPersonNavnQuery.kt
@@ -3,7 +3,7 @@ package no.nav.tiltakspenger.soknad.api.soknad.jobb.person
 import no.nav.tiltakspenger.libs.common.Fnr
 import no.nav.tiltakspenger.libs.personklient.pdl.GraphqlQuery
 
-fun hentPersonQuery(fnr: Fnr): GraphqlQuery {
+internal fun hentPersonNavnQuery(fnr: Fnr): GraphqlQuery {
     return GraphqlQuery(
         query = query,
         variables = mapOf(
@@ -15,15 +15,6 @@ fun hentPersonQuery(fnr: Fnr): GraphqlQuery {
 private val query = """
 query(${'$'}ident: ID!){
     hentPerson(ident: ${'$'}ident) {
-        adressebeskyttelse(historikk: false) {
-            gradering
-            folkeregistermetadata {
-                ...folkeregistermetadataDetails
-            }
-            metadata {
-                ...metadataDetails
-            }
-        }
         navn(historikk: false) {
             fornavn
             mellomnavn
@@ -35,12 +26,6 @@ query(${'$'}ident: ID!){
                 ...metadataDetails
             }
         }
-    },
-    hentGeografiskTilknytning(ident: ${'$'}ident) {
-        gtKommune
-        gtBydel
-        gtLand
-        gtType
     }
 }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/jobb/person/Person.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/jobb/person/Person.kt
@@ -1,0 +1,27 @@
+package no.nav.tiltakspenger.soknad.api.soknad.jobb.person
+
+import io.ktor.util.toUpperCasePreservingASCIIRules
+import no.nav.tiltakspenger.soknad.api.pdl.AdressebeskyttelseGradering
+import no.nav.tiltakspenger.soknad.api.pdl.Navn
+
+data class Person(
+    val navn: Navn,
+    val adressebeskyttelseGradering: AdressebeskyttelseGradering,
+    val geografiskTilknytning: GeografiskTilknytning?,
+)
+
+data class GeografiskTilknytning(
+    val gtType: String,
+    val gtKommune: String?,
+    val gtBydel: String?,
+    val gtLand: String?,
+) {
+    fun getGT(): String? =
+        when (gtType.toUpperCasePreservingASCIIRules()) {
+            "KOMMUNE" -> gtKommune
+            "BYDEL" -> gtBydel
+            "UTLAND" -> gtLand
+            "UDEFINERT" -> gtType
+            else -> null
+        }
+}

--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/jobb/person/PersonGateway.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/jobb/person/PersonGateway.kt
@@ -1,8 +1,0 @@
-package no.nav.tiltakspenger.soknad.api.soknad.jobb.person
-
-import no.nav.tiltakspenger.libs.common.Fnr
-import no.nav.tiltakspenger.libs.personklient.pdl.dto.Navn
-
-interface PersonGateway {
-    suspend fun hentNavnForFnr(fnr: Fnr): Navn
-}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -54,6 +54,7 @@ endpoints {
     tiltakspengertiltak = ${?TILTAKSPENGER_TILTAK_ENDPOINT_URL}
     tiltakspengervedtak = ${?TILTAKSPENGER_VEDTAK_ENDPOINT_URL}
     av = ${?AV_ENDPOINT_URL}
+    norg2 = ${?NORG2_ENDPOINT_URL}
 }
 
 unleash {
@@ -67,6 +68,7 @@ audience {
     joark = ${?JOARK_AUDIENCE}
     tiltakspengerarena = ${?TILTAKSPENGER_ARENA_AUDIENCE}
     tiltakspengertiltak = ${?TILTAKSPENGER_TILTAK_AUDIENCE}
+    norg2 = ${?NORG2_AUDIENCE}
 }
 
 scope {

--- a/src/test/resources/application.test.conf
+++ b/src/test/resources/application.test.conf
@@ -40,6 +40,8 @@ endpoints {
     joark = ${?JOARK_ENDPOINT_URL}
     tiltakspengerarena = ""
     tiltakspengerarena = ${?TILTAKSPENGER_ARENA_ENDPOINT_URL}
+    norg2 = ""
+    norg2 = ${?NORG2_ENDPOINT_URL}
 }
 
 audience {
@@ -49,6 +51,8 @@ audience {
     joark = ${?JOARK_AUDIENCE}
     tiltakspengerarena = ""
     tiltakspengerarena = ${?TILTAKSPENGER_ARENA_AUDIENCE}
+    norg2 = ""
+    norg2 = ${?NORG2_AUDIENCE}
 }
 
 scope {


### PR DESCRIPTION
## Beskrivelse
Klient for å hente arbeidsfordeling/journalførende enhet. I tillegg må vi hente GT fra PDL. Tanken min her er at vi først henter personen fra PDL, og så bruker vi denne for å finne journalførende enhet. Jeg har også flyttet koden for å lage accesstoken slik at man slipper å forholde seg til dette utenfor OAuth2Client. Burde sikkert ha endret overalt så alle klientene tar inn en funksjon for å hente tokenet også, men får ta en ting av gangen. Tester kommer når vi syr dette sammen, nå er det jo ikke så mye å teste ennå. 

## Kommentarer
https://trello.com/c/J9OTuMNe/1280-hente-journalf%C3%B8rende-enhet-fra-soknad-api
