### PR TITLE
1306 - Brukere behandlet i vår løsning må alltid få søknaden sin sendt til oss

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/Applikasjonseier.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/Applikasjonseier.kt
@@ -4,4 +4,22 @@ package no.nav.tiltakspenger.soknad.api.soknad
 enum class Applikasjonseier {
     Arena,
     Tiltakspenger,
+    ;
+
+    fun toDb(): String {
+        return when (this) {
+            Arena -> "arena"
+            Tiltakspenger -> "tp"
+        }
+    }
+
+    companion object {
+        fun toApplikasjonseier(eier: String): Applikasjonseier {
+            return when (eier) {
+                "arena" -> Arena
+                "tp" -> Tiltakspenger
+                else -> throw IllegalStateException("Ukjent eier i databasen: $eier. Forventet: ['arena','tp']")
+            }
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/NySøknadService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/NySøknadService.kt
@@ -14,8 +14,10 @@ class NySøknadService(
     fun nySøknad(
         nySøknadCommand: NySøknadCommand,
     ): Either<KunneIkkeMottaNySøknad, Unit> {
-        val eier: Applikasjonseier = if (Configuration.isProd()) {
-            // kommentar jah: Vi defaulter til Arena fram til vi tar over ruting. For MVP-brukerne våre endrer vi dette flagget direkte i databasen.
+        // Søknader sendes by default til arena i prod, med mindre brukeren har søknader hos oss fra før.
+        // Flagget endres manuelt for MVP-brukerne våre.
+        val brukerHarSøknaderSomEiesAvTiltakspenger = søknadRepo.hentBrukersSøknader(nySøknadCommand.fnr, Applikasjonseier.Tiltakspenger).isNotEmpty()
+        val eier: Applikasjonseier = if (Configuration.isProd() && !brukerHarSøknaderSomEiesAvTiltakspenger) {
             Applikasjonseier.Arena
         } else {
             Applikasjonseier.Tiltakspenger

--- a/src/test/kotlin/no/nav/tiltakspenger/soknad/api/repository/SøknadRepoTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/soknad/api/repository/SøknadRepoTest.kt
@@ -112,4 +112,21 @@ internal class SøknadRepoTest {
         val søknaderSomIkkeErSendtTilSaksbehandlingApi = søknadRepo.hentSøknaderSomSkalSendesTilSaksbehandlingApi()
         søknaderSomIkkeErSendtTilSaksbehandlingApi.size shouldBe 0
     }
+
+    @Test
+    fun `hent brukers søknader`() {
+        val nå = LocalDateTime.now()
+        val fnr = "12345678910"
+        val mottattSøknad = genererMottattSøknadForTest(
+            opprettet = nå,
+            eier = Applikasjonseier.Tiltakspenger,
+            fnr = fnr,
+        )
+        søknadRepo.lagre(mottattSøknad)
+
+        val brukersSøknader = søknadRepo.hentBrukersSøknader(fnr, Applikasjonseier.Tiltakspenger)
+        brukersSøknader.size shouldBe 1
+        brukersSøknader.first().fnr shouldBe fnr
+        brukersSøknader.first().eier shouldBe Applikasjonseier.Tiltakspenger
+    }
 }

--- a/src/test/kotlin/no/nav/tiltakspenger/soknad/api/soknad/NySøknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/soknad/api/soknad/NySøknadServiceTest.kt
@@ -1,0 +1,59 @@
+package no.nav.tiltakspenger.soknad.api.soknad
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verify
+import no.nav.tiltakspenger.soknad.api.Configuration
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class NySøknadServiceTest {
+    private val søknadRepo = mockk<SøknadRepo>(relaxed = true)
+    private val nySøknadService = NySøknadService(søknadRepo)
+    private lateinit var kommando: NySøknadCommand
+
+    @BeforeEach
+    fun setUp() {
+        kommando = NySøknadCommand(
+            brukersBesvarelser = mockk(),
+            acr = "Level4",
+            fnr = "12345678910",
+            vedlegg = listOf(),
+            innsendingTidspunkt = LocalDateTime.now(),
+        )
+        mockkObject(Configuration)
+    }
+
+    @Test
+    fun `eier settes til Arena i prod når bruker ikke har tidligere søknader som eies av Tiltakspenger`() {
+        every { Configuration.isProd() } returns true
+        every { søknadRepo.hentBrukersSøknader(any(), Applikasjonseier.Tiltakspenger) } returns emptyList()
+
+        val resultat = nySøknadService.nySøknad(kommando)
+
+        verify { søknadRepo.lagre(match { it.eier == Applikasjonseier.Arena }) }
+        resultat.isRight()
+    }
+
+    @Test
+    fun `eier settes til Tiltakspenger i prod når bruker har tidligere søknader som eies av Tiltakspenger`() {
+        every { Configuration.isProd() } returns true
+        every { søknadRepo.hentBrukersSøknader(any(), Applikasjonseier.Tiltakspenger) } returns listOf(mockk())
+
+        val resultat = nySøknadService.nySøknad(kommando)
+
+        verify { søknadRepo.lagre(match { it.eier == Applikasjonseier.Tiltakspenger }) }
+        resultat.isRight()
+    }
+
+    @Test
+    fun `eier settes til Tiltakspenger i dev`() {
+        every { Configuration.isProd() } returns false
+
+        val resultat = nySøknadService.nySøknad(kommando)
+        verify { søknadRepo.lagre(match { it.eier == Applikasjonseier.Tiltakspenger }) }
+        resultat.isRight()
+    }
+}

--- a/src/test/kotlin/no/nav/tiltakspenger/soknad/api/soknad/routes/SøknadRoutesTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/soknad/api/soknad/routes/SøknadRoutesTest.kt
@@ -40,6 +40,7 @@ internal class SøknadRoutesTest {
     private val avServiceMock = mockk<AvService>().also { mock ->
         coEvery { mock.gjørVirussjekkAvVedlegg(any()) } returns Unit
     }
+
     companion object {
         private val mockOAuth2Server = MockOAuth2Server()
 
@@ -174,6 +175,7 @@ internal class SøknadRoutesTest {
         mockkStatic("no.nav.tiltakspenger.soknad.api.soknad.routes.SoknadRequestMapperKt")
         coEvery { taInnSøknadSomMultipart(any()) } returns Pair(mockk(), emptyList())
         val søknadRepoMock = mockk<SøknadRepo>().also { mock ->
+            coEvery { mock.hentBrukersSøknader(any(), any()) } returns emptyList()
             coEvery { mock.lagre(any()) } returns Unit
         }
         val nySøknadService = NySøknadService(søknadRepoMock)


### PR DESCRIPTION
De kan ikke lenger behandlet i arena, så dermed må tiltakspenger ta eierskap over videre behandling av brukeren.

## Beskrivelse
Endret sjekken slik at søknader fra brukere som har fått saker behandlet hos oss alltid sendes til tiltakspenger.
La til litt mer type-safety rundt ApplikasjonsEier for å slippe copy&paste av strenger overalt 
