### PR TITLE
Nye prodbrukere

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/Application.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/Application.kt
@@ -13,7 +13,6 @@ import no.nav.tiltakspenger.libs.jobber.LeaderPodLookup
 import no.nav.tiltakspenger.libs.jobber.LeaderPodLookupClient
 import no.nav.tiltakspenger.libs.jobber.LeaderPodLookupFeil
 import no.nav.tiltakspenger.libs.jobber.RunCheckFactory
-import no.nav.tiltakspenger.libs.logging.sikkerlogg
 import no.nav.tiltakspenger.soknad.api.Configuration.httpPort
 import no.nav.tiltakspenger.soknad.api.antivirus.AvClient
 import no.nav.tiltakspenger.soknad.api.antivirus.AvService
@@ -56,8 +55,7 @@ internal fun start(
     val metricsCollector = MetricsCollector()
 
     Thread.setDefaultUncaughtExceptionHandler { _, e ->
-        log.error { "Uncaught exception logget i securelog" }
-        sikkerlogg.error(e) { e.message }
+        log.error(e) { e.message }
     }
     log.info { "starting server" }
 

--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/pdl/PdlClientTokenX.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/pdl/PdlClientTokenX.kt
@@ -44,7 +44,7 @@ class PdlClientTokenX(
                 setBody(hentPersonQuery(fødselsnummer))
             }.body<SøkerRespons>()
         }.getOrElse {
-            log.error(RuntimeException("Trigger stacktrace for enklere debug.")) { "PdlClientTokenX(fetchSøker): Kall mot PDL feilet. Token-exchange var OK. Kallid: $callId. Se sikkerlogg for mer kontekst." }
+            log.error(it) { "PdlClientTokenX(fetchSøker): Kall mot PDL feilet. Token-exchange var OK. Kallid: $callId. Se sikkerlogg for mer kontekst." }
             sikkerlogg.error(it) { "PdlClientTokenX(fetchSøker): Kall mot PDL feilet. Token-exchange var OK. Kallid: $callId." }
             throw it
         }
@@ -72,7 +72,7 @@ class PdlClientTokenX(
                 setBody(hentAdressebeskyttelseQuery(fødselsnummer))
             }.body<AdressebeskyttelseRespons>()
         }.getOrElse {
-            log.error(RuntimeException("Trigger stacktrace for enklere debug.")) { "PdlClientTokenX(fetchAdressebeskyttelse): Kall mot PDL feilet. Token-exchange var OK. Kallid: $callId. Se sikkerlogg for mer kontekst." }
+            log.error(it) { "PdlClientTokenX(fetchAdressebeskyttelse): Kall mot PDL feilet. Token-exchange var OK. Kallid: $callId. Se sikkerlogg for mer kontekst." }
             sikkerlogg.error(it) { "PdlClientTokenX(fetchAdressebeskyttelse): Kall mot PDL feilet. Token-exchange var OK. Kallid: $callId." }
             throw it
         }

--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/pdl/PdlRoutes.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/pdl/PdlRoutes.kt
@@ -1,5 +1,6 @@
 package no.nav.tiltakspenger.soknad.api.pdl
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.plugins.callid.callId
 import io.ktor.server.response.respond
@@ -7,7 +8,6 @@ import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.route
-import no.nav.tiltakspenger.libs.logging.sikkerlogg
 import no.nav.tiltakspenger.soknad.api.PERSONALIA_PATH
 import no.nav.tiltakspenger.soknad.api.auth.texas.TexasAuth
 import no.nav.tiltakspenger.soknad.api.auth.texas.client.TexasClient
@@ -23,6 +23,7 @@ fun Route.pdlRoutes(
     tiltakService: TiltakService,
     metricsCollector: MetricsCollector,
 ) {
+    val log = KotlinLogging.logger {}
     route(PERSONALIA_PATH) {
         install(TexasAuth) { client = texasClient }
         get {
@@ -45,7 +46,7 @@ fun Route.pdlRoutes(
                 call.respond(personDTO)
             } catch (e: Exception) {
                 metricsCollector.antallFeilVedHentPersonaliaCounter.inc()
-                sikkerlogg.error(e) { "Feil under pdlRoute" }
+                log.error(e) { "Feil under pdlRoute" }
                 call.respondText(status = HttpStatusCode.InternalServerError, text = "Internal Server Error")
             }
         }

--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/NySøknadService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/NySøknadService.kt
@@ -27,7 +27,7 @@ class NySøknadService(
             søknadRepo.lagre(søknad)
             log.info { "Søknad mottatt og lagret. SøknadId: ${søknad.id}. Acr: ${nySøknadCommand.acr}. Antall vedlegg: ${nySøknadCommand.vedlegg.size}. Innsendingstidspunkt: ${nySøknadCommand.innsendingTidspunkt}" }
         }.mapLeft {
-            log.error(RuntimeException("Trigger stacktrace for enklere debug.")) { "Feil under lagring av søknad. Se sikkerlogg for mer kontekst. Antall vedlegg: ${nySøknadCommand.vedlegg.size}. Innsendingstidspunkt: ${nySøknadCommand.innsendingTidspunkt}" }
+            log.error(it) { "Feil under lagring av søknad. Se sikkerlogg for mer kontekst. Antall vedlegg: ${nySøknadCommand.vedlegg.size}. Innsendingstidspunkt: ${nySøknadCommand.innsendingTidspunkt}" }
             sikkerlogg.error(it) { "Feil under lagring av søknad. Antall vedlegg: ${nySøknadCommand.vedlegg.size}. Innsendingstidspunkt: ${nySøknadCommand.innsendingTidspunkt}. Fnr: ${nySøknadCommand.fnr}. " }
             KunneIkkeMottaNySøknad.KunneIkkeLagreSøknad
         }

--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/NySøknadService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/NySøknadService.kt
@@ -10,18 +10,16 @@ class NySøknadService(
 ) {
     private val log = KotlinLogging.logger {}
 
+    private val deltakerIderSomSkalTilTpsak = listOf(
+        "0261ee55-c16d-48f8-9e07-ea101856e72d",
+        "0b9d57f0-0ece-44f3-a918-d0721ec526ca",
+    )
+
     // TODO post-mvp jah: Flytt domenelogikk fra route og inn hit.
     fun nySøknad(
         nySøknadCommand: NySøknadCommand,
     ): Either<KunneIkkeMottaNySøknad, Unit> {
-        // Søknader sendes by default til arena i prod, med mindre brukeren har søknader hos oss fra før.
-        // Flagget endres manuelt for MVP-brukerne våre.
-        val brukerHarSøknaderSomEiesAvTiltakspenger = søknadRepo.hentBrukersSøknader(nySøknadCommand.fnr, Applikasjonseier.Tiltakspenger).isNotEmpty()
-        val eier: Applikasjonseier = if (Configuration.isProd() && !brukerHarSøknaderSomEiesAvTiltakspenger) {
-            Applikasjonseier.Arena
-        } else {
-            Applikasjonseier.Tiltakspenger
-        }
+        val eier = getEier(nySøknadCommand)
         val søknad: MottattSøknad = nySøknadCommand.toDomain(eier)
         return Either.catch {
             søknadRepo.lagre(søknad)
@@ -30,6 +28,20 @@ class NySøknadService(
             log.error(it) { "Feil under lagring av søknad. Se sikkerlogg for mer kontekst. Antall vedlegg: ${nySøknadCommand.vedlegg.size}. Innsendingstidspunkt: ${nySøknadCommand.innsendingTidspunkt}" }
             sikkerlogg.error(it) { "Feil under lagring av søknad. Antall vedlegg: ${nySøknadCommand.vedlegg.size}. Innsendingstidspunkt: ${nySøknadCommand.innsendingTidspunkt}. Fnr: ${nySøknadCommand.fnr}. " }
             KunneIkkeMottaNySøknad.KunneIkkeLagreSøknad
+        }
+    }
+
+    // Søknader sendes by default til arena i prod, med mindre brukeren har søknader hos oss fra før, eller blir
+    // manuelt lagt til i listen over deltakere som skal til oss.
+    private fun getEier(nySøknadCommand: NySøknadCommand): Applikasjonseier {
+        val brukerHarSøknaderSomEiesAvTiltakspenger =
+            søknadRepo.hentBrukersSøknader(nySøknadCommand.fnr, Applikasjonseier.Tiltakspenger).isNotEmpty()
+        val brukerErForhandsgodkjent = nySøknadCommand.brukersBesvarelser.tiltak.aktivitetId in deltakerIderSomSkalTilTpsak
+
+        return if (Configuration.isProd() && !brukerHarSøknaderSomEiesAvTiltakspenger && !brukerErForhandsgodkjent) {
+            Applikasjonseier.Arena
+        } else {
+            Applikasjonseier.Tiltakspenger
         }
     }
 }

--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/jobb/SøknadJobbService.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/jobb/SøknadJobbService.kt
@@ -47,7 +47,7 @@ class SøknadJobbService(
             val navn = try {
                 personHttpklient.hentNavnForFnr(Fnr.fromString(søknad.fnr))
             } catch (e: Exception) {
-                log.error(RuntimeException("Trigger stacktrace for enklere debug.")) { "Journalfør søknad jobb: Feil ved henting av navn fra PDL for søknadId ${søknad.id}" }
+                log.error(e) { "Journalfør søknad jobb: Feil ved henting av navn fra PDL for søknadId ${søknad.id}" }
                 sikkerlogg.error(e) { "Journalfør søknad jobb: Feil ved henting av navn fra PDL for søknadId ${søknad.id}" }
                 return@forEach
             }
@@ -65,7 +65,7 @@ class SøknadJobbService(
                     callId = correlationId.toString(),
                 )
             } catch (e: Exception) {
-                log.error(RuntimeException("Trigger stacktrace for enklere debug.")) { "Journalfør søknad jobb: Feil under journalføring mot Dokarkiv for søknadId ${søknad.id}" }
+                log.error(e) { "Journalfør søknad jobb: Feil under journalføring mot Dokarkiv for søknadId ${søknad.id}" }
                 sikkerlogg.error(e) { "Journalfør søknad jobb: Feil under journalføring mot Dokarkiv for søknadId ${søknad.id}" }
                 return@forEach
             }
@@ -101,7 +101,7 @@ class SøknadJobbService(
                 søknadRepo.oppdater(søknad.copy(sendtTilVedtak = sendtTilSaksbehandlingApi))
                 log.info { "Send søknad til saksbehandling-api jobb: Oppdatert utsendingstidspunktet til $sendtTilSaksbehandlingApi for søknad ${søknad.id}" }
             } catch (e: Exception) {
-                log.error(RuntimeException("Trigger stacktrace for enklere debug.")) { "Send søknad til saksbehandling-api jobb: Feil ved sending av søknad ${søknad.id} til saksbehandling-api. Denne vil prøves på nytt. Se sikkerlogg for mer info." }
+                log.error(e) { "Send søknad til saksbehandling-api jobb: Feil ved sending av søknad ${søknad.id} til saksbehandling-api. Denne vil prøves på nytt. Se sikkerlogg for mer info." }
                 sikkerlogg.error(e) { "Send søknad til saksbehandling-api jobb:  Feil ved sending av søknad ${søknad.id} til saksbehandling-api. Denne vil prøves på nytt." }
             }
         }

--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/routes/SøknadRoutes.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/routes/SøknadRoutes.kt
@@ -12,7 +12,6 @@ import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
-import no.nav.tiltakspenger.libs.logging.sikkerlogg
 import no.nav.tiltakspenger.soknad.api.SØKNAD_PATH
 import no.nav.tiltakspenger.soknad.api.antivirus.AvService
 import no.nav.tiltakspenger.soknad.api.antivirus.MalwareFoundException
@@ -84,7 +83,7 @@ fun Route.søknadRoutes(
                     is UninitializedPropertyAccessException,
                     is RequestValidationException,
                     -> {
-                        sikkerlogg.error(exception) { "Ugyldig søknad: ${exception.message}" }
+                        log.error(exception) { "Ugyldig søknad: ${exception.message}" }
                         metricsCollector.antallFeiledeInnsendingerCounter.inc()
                         metricsCollector.antallUgyldigeSøknaderCounter.inc()
                         requestTimer.observeDuration()

--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/tiltak/TiltakRoutes.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/tiltak/TiltakRoutes.kt
@@ -47,7 +47,7 @@ fun Route.tiltakRoutes(
 
                 call.respond(tiltakDto)
             } catch (e: Exception) {
-                log.error(RuntimeException("Trigger exception for enklere debugging.")) { "Ukjent feil under tiltakroute, se sikkerlogg for mer kontekst." }
+                log.error(e) { "Ukjent feil under tiltakroute, se sikkerlogg for mer kontekst." }
                 sikkerlogg.error(e) { "Ukjent feil under tiltakroute" }
                 metricsCollector.antallFeilVedHentTiltakCounter.inc()
                 call.respondText(status = HttpStatusCode.InternalServerError, text = "Internal Server Error")

--- a/src/test/kotlin/no/nav/tiltakspenger/soknad/api/soknad/routes/SøknadRoutesTest.kt
+++ b/src/test/kotlin/no/nav/tiltakspenger/soknad/api/soknad/routes/SøknadRoutesTest.kt
@@ -20,6 +20,7 @@ import no.nav.tiltakspenger.soknad.api.antivirus.AvService
 import no.nav.tiltakspenger.soknad.api.auth.texas.client.TexasClient
 import no.nav.tiltakspenger.soknad.api.auth.texas.client.TexasIntrospectionResponse
 import no.nav.tiltakspenger.soknad.api.configureTestApplication
+import no.nav.tiltakspenger.soknad.api.mockSpørsmålsbesvarelser
 import no.nav.tiltakspenger.soknad.api.pdl.AdressebeskyttelseGradering.UGRADERT
 import no.nav.tiltakspenger.soknad.api.pdl.PdlService
 import no.nav.tiltakspenger.soknad.api.pdl.PersonDTO
@@ -200,7 +201,7 @@ internal class SøknadRoutesTest {
     @Test
     fun `post på soknad-endepunkt skal svare med 201 Created ved gyldig søknad `() {
         mockkStatic("no.nav.tiltakspenger.soknad.api.soknad.routes.SoknadRequestMapperKt")
-        coEvery { taInnSøknadSomMultipart(any()) } returns Pair(mockk(), emptyList())
+        coEvery { taInnSøknadSomMultipart(any()) } returns Pair(mockSpørsmålsbesvarelser(), emptyList())
         val søknadRepoMock = mockk<SøknadRepo>().also { mock ->
             coEvery { mock.hentBrukersSøknader(any(), any()) } returns emptyList()
             coEvery { mock.lagre(any()) } returns Unit


### PR DESCRIPTION
## Beskrivelse
Hvis det kommer en søknad på to konkrete tiltaksdeltakelser så skal disse rutes til oss :)

Har også endret slik at feilmeldinger kommer i vanlig logg så vi slipper å gå inn i sikkerlogg bare for å se en stacktrace (fnr maskeres uansett). 

## Kommentarer
https://trello.com/c/j1OTX3RK/1408-legge-til-rette-for-to-nye-brukere-i-prod-hvis-de-velger-%C3%A5-s%C3%B8ke
