### PR TITLE
1524 kaster feil hvis virusscan mot formodning skulle returnere error

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/antivirus/AvServiceImpl.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/antivirus/AvServiceImpl.kt
@@ -18,8 +18,9 @@ class AvServiceImpl(
                 log.info { "Fant skadevare i vedlegg ${it.filnavn}" }
             }
             if (it.resultat === Status.ERROR) {
-                // TODO post-mvp jah: Så hvis vi ikke klarer å scanne en fil, godtar vi den bare. Er dette ønsket oppførsel? Hva sier ROSen om dette? Finner ingen innslag i loggen.
-                log.error { "Noe gikk galt under virusscan av fil ${it.filnavn}" }
+                val feilmelding = "Noe gikk galt under virusscan av fil ${it.filnavn}"
+                log.error { feilmelding }
+                throw RuntimeException(feilmelding)
             }
         }
 


### PR DESCRIPTION
Siden dette såvidt jeg kan se utifra loggene aldri skjer kaster jeg bare en runtime exception i stedet for å lage noe custom. Hvis det mot formodning skulle skje kan vi heller lage bedre håndtering. 

https://trello.com/c/qVfHUnwm/1524-hvis-vi-ikke-f%C3%A5r-scannet-s%C3%B8knadsvedlegg-s%C3%A5-b%C3%B8r-det-feile