### PR TITLE
1587 ruter kode6-brukere til arena hvis de ikke er tatt over av oss f…

### DIFF
--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/KtorSetup.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/KtorSetup.kt
@@ -88,6 +88,7 @@ internal fun Application.setupRouting(
                 avService = avService,
                 metricsCollector = metricsCollector,
                 nySøknadService = nySøknadService,
+                pdlService = pdlService,
             )
             tiltakRoutes(
                 tiltakService = tiltakService,

--- a/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/routes/SøknadRoutes.kt
+++ b/src/main/kotlin/no/nav/tiltakspenger/soknad/api/soknad/routes/SøknadRoutes.kt
@@ -6,6 +6,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.auth.principal
 import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.plugins.CannotTransformContentToTypeException
+import io.ktor.server.plugins.callid.callId
 import io.ktor.server.plugins.requestvalidation.RequestValidationException
 import io.ktor.server.request.receiveMultipart
 import io.ktor.server.response.respond
@@ -18,6 +19,7 @@ import no.nav.tiltakspenger.soknad.api.SØKNAD_PATH
 import no.nav.tiltakspenger.soknad.api.antivirus.AvService
 import no.nav.tiltakspenger.soknad.api.antivirus.MalwareFoundException
 import no.nav.tiltakspenger.soknad.api.metrics.MetricsCollector
+import no.nav.tiltakspenger.soknad.api.pdl.PdlService
 import no.nav.tiltakspenger.soknad.api.soknad.NySøknadCommand
 import no.nav.tiltakspenger.soknad.api.soknad.NySøknadService
 import java.time.LocalDateTime
@@ -26,6 +28,7 @@ fun Route.søknadRoutes(
     nySøknadService: NySøknadService,
     avService: AvService,
     metricsCollector: MetricsCollector,
+    pdlService: PdlService,
 ) {
     val log = KotlinLogging.logger { }
     route(SØKNAD_PATH) {
@@ -33,13 +36,19 @@ fun Route.søknadRoutes(
             log.info { "Mottatt kall til $SØKNAD_PATH" }
             val requestTimer = metricsCollector.søknadsmottakLatencySeconds.startTimer()
             try {
-                val principal = call.principal<TexasPrincipalExternalUser>() ?: throw IllegalStateException("Mangler principal")
+                val principal =
+                    call.principal<TexasPrincipalExternalUser>() ?: throw IllegalStateException("Mangler principal")
                 val innsendingTidspunkt = LocalDateTime.now()
                 val (brukersBesvarelser, vedlegg) = taInnSøknadSomMultipart(call.receiveMultipart())
                 log.info { "Utfører virussjekk" }
                 avService.gjørVirussjekkAvVedlegg(vedlegg)
                 val fødselsnummer = principal.fnr
                 val acr = principal.claims["acr"]!!.toString()
+                val adressebeskyttelse = pdlService.hentAdressebeskyttelse(
+                    fødselsnummer = fødselsnummer.verdi,
+                    subjectToken = principal.token,
+                    callId = call.callId!!,
+                )
 
                 val command = NySøknadCommand(
                     brukersBesvarelser = brukersBesvarelser,
@@ -48,7 +57,7 @@ fun Route.søknadRoutes(
                     vedlegg = vedlegg,
                     innsendingTidspunkt = innsendingTidspunkt,
                 )
-                nySøknadService.nySøknad(command).fold(
+                nySøknadService.nySøknad(command, adressebeskyttelse).fold(
                     {
                         metricsCollector.antallFeiledeInnsendingerCounter.inc()
                         requestTimer.observeDuration()


### PR DESCRIPTION
…ra før

Har også lagt på caching av kallet for å hente adressebeskyttelse siden vi må gjøre det to ganger i søknadsprosessen. 

Logikken som jeg la til i routinglaget burde egentlig vært lenger inn, men det er så mye annen logikk der uansett at det virket rart å sende subjekttoken videre innover i stedet for å bare gjøre kallet med en gang 🤷‍♀️ 

https://trello.com/c/zDaJMwP2/1587-rute-kode-6-brukere-til-arena